### PR TITLE
Fix sentry integration

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@ Thanks to:
 * allisson <allisson@olist.com>
 * cleberzavadniak <cleber.zavadniak@olist.com>
 * lamenezes <luiz.menezes@olist.com>
+* luizdepra <luiz.pra@olist.com>

--- a/loafer/dispatchers.py
+++ b/loafer/dispatchers.py
@@ -1,3 +1,4 @@
+import sys
 import asyncio
 import logging
 
@@ -30,7 +31,8 @@ class LoaferDispatcher:
                 logger.warning(msg.format(route.handler, message))
             except Exception as exc:
                 logger.exception('{!r}'.format(exc))
-                confirm_message = await route.error_handler(type(exc), exc, message)
+                exc_info = sys.exc_info()
+                confirm_message = await route.error_handler(exc_info, message)
 
         return confirm_message
 

--- a/loafer/ext/sentry.py
+++ b/loafer/ext/sentry.py
@@ -4,8 +4,9 @@
 
 def sentry_handler(client, delete_message=False):
 
-    def send_to_sentry(exc_type, exc, message):
+    def send_to_sentry(exc_info, message):
         client.captureException(
+            exc_info,
             extra={'message': message},
         )
         return delete_message

--- a/loafer/routes.py
+++ b/loafer/routes.py
@@ -45,13 +45,13 @@ class Route:
             loop = loop or asyncio.get_event_loop()
             return await loop.run_in_executor(None, self.handler, message['content'], message['metadata'])
 
-    async def error_handler(self, exc_type, exc, message, loop=None):
+    async def error_handler(self, exc_info, message, loop=None):
         logger.info('error handler process originated by message={}'.format(message))
         if self._error_handler is not None:
             if asyncio.iscoroutinefunction(self._error_handler):
-                return await self._error_handler(exc_type, exc, message)
+                return await self._error_handler(exc_info, message)
             else:
                 loop = loop or asyncio.get_event_loop()
-                return await loop.run_in_executor(None, self._error_handler, exc_type, exc, message)
+                return await loop.run_in_executor(None, self._error_handler, exc_info, message)
 
         return False

--- a/tests/ext/test_sentry.py
+++ b/tests/ext/test_sentry.py
@@ -7,7 +7,8 @@ def test_sentry_handler():
     mocked_client = mock.Mock()
     handler = sentry_handler(mocked_client)
     exc = ValueError('test')
-    delete_message = handler(type(exc), exc, 'test')
+    exc_info = (type(exc), exc, None)
+    delete_message = handler(exc_info, 'test')
 
     assert delete_message is False
     assert mocked_client.captureException.called
@@ -18,7 +19,8 @@ def test_sentry_handler_delete_message():
     mocked_client = mock.Mock()
     handler = sentry_handler(mocked_client, delete_message=True)
     exc = ValueError('test')
-    delete_message = handler(type(exc), exc, 'test')
+    exc_info = (type(exc), exc, None)
+    delete_message = handler(exc_info, 'test')
 
     assert delete_message is True
     assert mocked_client.captureException.called

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -75,7 +75,7 @@ async def test_dispatch_message_task_error(route):
     assert route.deliver.called is True
     route.deliver.assert_called_once_with(message)
     assert route.error_handler.called is True
-    route.error_handler.assert_called_once_with(type(exc), exc, message)
+    route.error_handler.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -75,7 +75,6 @@ async def test_dispatch_message_task_error(route):
     assert route.deliver.called is True
     route.deliver.assert_called_once_with(message)
     assert route.error_handler.called is True
-    route.error_handler.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -50,7 +50,8 @@ def test_apply_message_translator_error():
 async def test_error_handler_unset():
     route = Route('foo', mock.Mock())
     exc = TypeError()
-    result = await route.error_handler(type(exc), exc, 'whatever')
+    exc_info = (type(exc), exc, None)
+    result = await route.error_handler(exc_info, 'whatever')
     assert result is False
 
 
@@ -58,9 +59,8 @@ async def test_error_handler_unset():
 async def test_error_handler():
     attrs = {}
 
-    def error_handler(exc_type, exc, message):
-        attrs['exc_type'] = exc_type
-        attrs['exc'] = exc
+    def error_handler(exc_info, message):
+        attrs['exc_info'] = exc_info
         attrs['message'] = message
         return True
 
@@ -68,10 +68,10 @@ async def test_error_handler():
     # be checked with asyncio.iscoroutinefunction() and pass as coro
     route = Route('foo', mock.Mock(), error_handler=error_handler)
     exc = TypeError()
-    result = await route.error_handler(type(exc), exc, 'whatever')
+    exc_info = (type(exc), exc, 'traceback')
+    result = await route.error_handler(exc_info, 'whatever')
     assert result is True
-    assert attrs['exc_type'] == type(exc)
-    assert attrs['exc'] == exc
+    assert attrs['exc_info'] == exc_info
     assert attrs['message'] == 'whatever'
 
 
@@ -80,10 +80,11 @@ async def test_error_handler_coroutine():
     error_handler = CoroutineMock(return_value=True)
     route = Route('foo', mock.Mock(), error_handler=error_handler)
     exc = TypeError()
-    result = await route.error_handler(type(exc), exc, 'whatever')
+    exc_info = (type(exc), exc, 'traceback')
+    result = await route.error_handler(exc_info, 'whatever')
     assert result is True
     assert error_handler.called
-    error_handler.assert_called_once_with(type(exc), exc, 'whatever')
+    error_handler.assert_called_once_with(exc_info, 'whatever')
 
 
 # FIXME: Improve all test_deliver* tests


### PR DESCRIPTION
The sentry integration isn't working.

The raven client's `captureException()` is unable to get exc_info from `sys.exc_info()` because the `error_handler` is called asynchronously. So, we have to extract exc_info and pass it to the handler. 