### PR TITLE
Fix sns topic arn prefix from arn:sns: to arn:aws:sns:

### DIFF
--- a/loafer/ext/aws/bases.py
+++ b/loafer/ext/aws/bases.py
@@ -50,9 +50,10 @@ class BaseSNSClient:
         return session.create_client('sns', endpoint_url=self.endpoint_url, use_ssl=self.use_ssl)
 
     async def get_topic_arn(self, topic):
-        if topic.startswith('arn:sns:'):
+        arn_prefix = 'arn:aws:sns:'
+        if topic.startswith(arn_prefix):
             return topic
-        return 'arn:sns:*:{}'.format(topic)
+        return '{}*:{}'.format(arn_prefix, topic)
 
     def stop(self):
         logger.info('closing client={}'.format(self.client))

--- a/tests/ext/aws/test_bases.py
+++ b/tests/ext/aws/test_bases.py
@@ -56,13 +56,13 @@ def base_sns_client():
 @pytest.mark.asyncio
 async def test_get_topic_arn_using_topic_name(base_sns_client):
     arn = await base_sns_client.get_topic_arn('topic-name')
-    assert arn == 'arn:sns:*:topic-name'
+    assert arn == 'arn:aws:sns:*:topic-name'
 
 
 @pytest.mark.asyncio
 async def test_cache_get_topic_arn_with_arn(base_sns_client):
-    arn = await base_sns_client.get_topic_arn('arn:sns:whatever:topic-name')
-    assert arn == 'arn:sns:whatever:topic-name'
+    arn = await base_sns_client.get_topic_arn('arn:aws:sns:whatever:topic-name')
+    assert arn == 'arn:aws:sns:whatever:topic-name'
 
 
 def test_sns_close(base_sns_client):

--- a/tests/ext/aws/test_handlers.py
+++ b/tests/ext/aws/test_handlers.py
@@ -59,7 +59,7 @@ async def test_sqs_handler_hadle():
 @pytest.mark.asyncio
 @pytest.mark.parametrize('encoder', [json.dumps, str])
 async def test_sns_handler_publisher(mock_boto_session_sns, boto_client_sns, encoder):
-    handler = SNSHandler('arn:sns:whatever:topic-name')
+    handler = SNSHandler('arn:aws:sns:whatever:topic-name')
     with mock_boto_session_sns as mock_sns:
         retval = await handler.publish('message', encoder=encoder)
         assert retval
@@ -67,14 +67,14 @@ async def test_sns_handler_publisher(mock_boto_session_sns, boto_client_sns, enc
         assert mock_sns.called
         assert boto_client_sns.publish.called
         assert boto_client_sns.publish.call_args == mock.call(
-            TopicArn='arn:sns:whatever:topic-name',
+            TopicArn='arn:aws:sns:whatever:topic-name',
             MessageStructure='json',
             Message=json.dumps({'default': encoder('message')}))
 
 
 @pytest.mark.asyncio
 async def test_sns_handler_publisher_without_encoder(mock_boto_session_sns, boto_client_sns):
-    handler = SNSHandler('arn:sns:whatever:topic-name')
+    handler = SNSHandler('arn:aws:sns:whatever:topic-name')
     with mock_boto_session_sns as mock_sns:
         retval = await handler.publish('message', encoder=None)
         assert retval
@@ -82,7 +82,7 @@ async def test_sns_handler_publisher_without_encoder(mock_boto_session_sns, boto
         assert mock_sns.called
         assert boto_client_sns.publish.called
         assert boto_client_sns.publish.call_args == mock.call(
-            TopicArn='arn:sns:whatever:topic-name',
+            TopicArn='arn:aws:sns:whatever:topic-name',
             MessageStructure='json',
             Message=json.dumps({'default': 'message'}))
 


### PR DESCRIPTION
As it's explained in docs [1]. SNS topic names are prefixed by `arn:aws:sns` and not `arn:sns` as it is currently being used by `loafer.ext.aws.bases.BaseSNSClient.get_topic_arn`.

Using loafer's sns client to publish a message to a topic the following error happens:

```
botocore.errorfactory.InvalidParameterException: An error occurred (InvalidParameter) when calling the Publish operation: Invalid parameter: TopicArn Reason: A arn ARN must begin with arn:null, not arn:sns:*:arn:aws:sns:us-east-1:412729474065:notificaftion__product
```

This PR fixes this problem.

[1] http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html