### PR TITLE
Stop passing loop around + remove deprecated args

### DIFF
--- a/loafer/dispatchers.py
+++ b/loafer/dispatchers.py
@@ -48,7 +48,7 @@ class LoaferDispatcher:
         messages = await route.provider.fetch_messages()
         return messages, route
 
-    async def _dispatch_tasks(self, loop):
+    async def _dispatch_tasks(self):
         provider_messages_tasks = [
             self._get_route_messages(route) for route in self.routes
         ]
@@ -64,11 +64,11 @@ class LoaferDispatcher:
         if not process_messages_tasks:
             return
 
-        await asyncio.wait(process_messages_tasks, loop=loop)
+        await asyncio.gather(*process_messages_tasks)
 
-    async def dispatch_providers(self, loop, forever=True):
+    async def dispatch_providers(self, forever=True):
         while True:
-            await self._dispatch_tasks(loop)
+            await self._dispatch_tasks()
 
             if not forever:
                 break

--- a/loafer/ext/aws/bases.py
+++ b/loafer/ext/aws/bases.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 import aiobotocore
@@ -10,7 +9,7 @@ logger = logging.getLogger(__name__)
 class _BotoClient:
     boto_service_name = None
 
-    def __init__(self, loop=None, **client_options):
+    def __init__(self, **client_options):
         self._client_options = {
             'api_version': client_options.get('api_version', None),
             'aws_access_key_id': client_options.get('aws_access_key_id', None),
@@ -21,11 +20,10 @@ class _BotoClient:
             'use_ssl': client_options.get('use_ssl', True),
             'verify': client_options.get('verify', None),
         }
-        self._loop = loop or asyncio.get_event_loop()
 
     @cached_property
     def client(self):
-        session = aiobotocore.get_session(loop=self._loop)
+        session = aiobotocore.get_session()
         return session.create_client(self.boto_service_name, **self._client_options)
 
 

--- a/loafer/ext/aws/providers.py
+++ b/loafer/ext/aws/providers.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import botocore.exceptions
@@ -44,5 +45,6 @@ class SQSProvider(AbstractProvider, BaseSQSClient):
 
     def stop(self):
         logger.info('stopping {}'.format(self))
-        self._loop.run_until_complete(self.client.close())
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.client.close())
         return super().stop()

--- a/loafer/managers.py
+++ b/loafer/managers.py
@@ -33,7 +33,7 @@ class LoaferManager:
     def run(self, forever=True, debug=False):
         loop = self.runner.loop
         self._future = asyncio.ensure_future(
-            self.dispatcher.dispatch_providers(loop, forever=forever),
+            self.dispatcher.dispatch_providers(forever=forever),
             loop=loop,
         )
 

--- a/loafer/routes.py
+++ b/loafer/routes.py
@@ -64,12 +64,12 @@ class Route:
 
         return processed_message
 
-    async def deliver(self, raw_message, loop=None):
+    async def deliver(self, raw_message):
         message = self.apply_message_translator(raw_message)
         logger.info('delivering message route={}, message={!r}'.format(self, message))
         return await run_in_loop_or_executor(self.handler, message['content'], message['metadata'])
 
-    async def error_handler(self, exc_info, message, loop=None):
+    async def error_handler(self, exc_info, message):
         logger.info('error handler process originated by message={}'.format(message))
 
         if self._error_handler is not None:

--- a/loafer/runners.py
+++ b/loafer/runners.py
@@ -9,15 +9,18 @@ logger = logging.getLogger(__name__)
 
 class LoaferRunner:
 
-    def __init__(self, loop=None, max_workers=None, on_stop_callback=None):
+    def __init__(self, max_workers=None, on_stop_callback=None):
         self._on_stop_callback = on_stop_callback
-        self.loop = loop or asyncio.get_event_loop()
 
         # XXX: See https://github.com/python/asyncio/issues/258
         # The minimum value depends on the number of cores in the machine
         # See https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
         self._executor = ThreadPoolExecutor(max_workers)
         self.loop.set_default_executor(self._executor)
+
+    @property
+    def loop(self):
+        return asyncio.get_event_loop()
 
     def start(self, future=None, run_forever=None, debug=False):
         if debug:

--- a/loafer/runners.py
+++ b/loafer/runners.py
@@ -22,18 +22,9 @@ class LoaferRunner:
     def loop(self):
         return asyncio.get_event_loop()
 
-    def start(self, future=None, run_forever=None, debug=False):
+    def start(self, debug=False):
         if debug:
             self.loop.set_debug(enabled=debug)
-
-        if future:
-            logger.warning(
-                'runner `future` argument is deprecated and will be removed in the next major version'
-            )
-        if run_forever:
-            logger.warning(
-                'runner `run_forever` argument is deprecated and will be removed in the next major version'
-            )
 
         self.loop.add_signal_handler(signal.SIGINT, self.prepare_stop)
         self.loop.add_signal_handler(signal.SIGTERM, self.prepare_stop)

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -104,10 +104,10 @@ async def test_message_processing(route):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_tasks(route, event_loop):
+async def test_dispatch_tasks(route):
     route.provider.fetch_messages = CoroutineMock(return_value=['message'])
     dispatcher = LoaferDispatcher([route])
-    await dispatcher._dispatch_tasks(event_loop)
+    await dispatcher._dispatch_tasks()
 
     assert route.provider.fetch_messages.called
     assert route.provider.confirm_message.called
@@ -117,7 +117,7 @@ async def test_dispatch_tasks(route, event_loop):
 async def test_dispatch_without_tasks(route, event_loop):
     route.provider.fetch_messages = CoroutineMock(return_value=[])
     dispatcher = LoaferDispatcher([route])
-    await dispatcher._dispatch_tasks(event_loop)
+    await dispatcher._dispatch_tasks()
 
     assert route.provider.fetch_messages.called
     assert route.provider.confirm_message.called is False
@@ -128,10 +128,10 @@ async def test_dispatch_providers(route, event_loop):
     dispatcher = LoaferDispatcher([route])
     dispatcher._dispatch_tasks = CoroutineMock()
     dispatcher.stop_providers = Mock()
-    await dispatcher.dispatch_providers(event_loop, forever=False)
+    await dispatcher.dispatch_providers(forever=False)
 
     assert dispatcher._dispatch_tasks.called
-    dispatcher._dispatch_tasks.assert_called_once_with(event_loop)
+    dispatcher._dispatch_tasks.assert_called_once_with()
 
 
 @pytest.mark.asyncio
@@ -139,7 +139,7 @@ async def test_dispatch_providers_with_error(route, event_loop):
     route.provider.fetch_messages.side_effect = ValueError
     dispatcher = LoaferDispatcher([route])
     with pytest.raises(ValueError):
-        await dispatcher.dispatch_providers(event_loop, forever=False)
+        await dispatcher.dispatch_providers(forever=False)
 
 
 def test_dispatcher_stop(route):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -26,7 +26,7 @@ def test_runner_start_and_stop(loop_mock):
     runner = LoaferRunner()
     runner.stop = mock.Mock()
 
-    runner.start(run_forever=False)
+    runner.start()
 
     assert runner.stop.called
     assert loop_mock.return_value.run_forever.called


### PR DESCRIPTION
On newer python/asyncio versions loops shouldn't be passed around. When necessary they must be invoked via `asyncio.get_event_loop`.

From my tests using python 3.5.7 I believe this change won't break loafer on older python versions. Although on some edge cases (if the user perform some crazy loop handling) problems might appear.