### PR TITLE
Testing local install with pip instead of setuptools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements/test.txt
-            python3 setup.py develop
+            pip install -e .
 
       - save_cache:
           key: deps-{{ .Branch }}-{{ checksum "setup.py" }}


### PR DESCRIPTION
After some investigation, I find that `setup.py develop` don't exclude pre-releases from dependencies and that was breaking the `python3.5` build.
In the current state, the package `yarl-1.4.0a11` was installed and it is `3.6+` only.