### PR TITLE
Use method cancel all tasks from runner

### DIFF
--- a/loafer/runners.py
+++ b/loafer/runners.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import signal
+from asyncio.runners import _cancel_all_tasks as cancel_all_tasks
 from concurrent.futures import CancelledError, ThreadPoolExecutor
 from contextlib import suppress
 
@@ -48,12 +49,7 @@ class LoaferRunner:
             self._on_stop_callback()
 
         logger.info('cancel schedulled operations ...')
-        for task in asyncio.Task.all_tasks(self.loop):
-            task.cancel()
-            if task.cancelled() or task.done():
-                continue
-
-            with suppress(CancelledError):
-                self.loop.run_until_complete(task)
+        with suppress(CancelledError):
+            cancel_all_tasks(self.loop)
 
         self._executor.shutdown(wait=True)

--- a/loafer/runners.py
+++ b/loafer/runners.py
@@ -43,7 +43,7 @@ class LoaferRunner:
             self.loop.stop()
 
     def _cancel_all_tasks(self):
-        to_cancel = asyncio.all_tasks(self.loop)
+        to_cancel = asyncio.Task.all_tasks(self.loop)
         if not to_cancel:
             return
         for task in to_cancel:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -70,13 +70,18 @@ def test_runner_stop_with_callback(loop_mock):
 
 def test_runner_stop_dont_raise_cancelled_error():
     async def some_coro():
-        await asyncio.sleep(1)
         raise asyncio.CancelledError()
 
     runner = LoaferRunner()
     loop = runner.loop
     task = loop.create_task(some_coro())
+
+    assert task.done() is False
+    assert task.cancelled() is False
+
     runner.stop()
+
+    assert task.done() is True
     assert task.cancelled() is True
     with pytest.raises(asyncio.CancelledError):
         task.exception()

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1,4 +1,7 @@
+import asyncio
 from unittest import mock
+
+import pytest
 
 from loafer.runners import LoaferRunner
 
@@ -63,3 +66,17 @@ def test_runner_stop_with_callback(loop_mock):
     runner.stop()
 
     assert callback.called
+
+
+def test_runner_stop_dont_raise_cancelled_error():
+    async def some_coro():
+        await asyncio.sleep(1)
+        raise asyncio.CancelledError()
+
+    runner = LoaferRunner()
+    loop = runner.loop
+    task = loop.create_task(some_coro())
+    runner.stop()
+    assert task.cancelled() is True
+    with pytest.raises(asyncio.CancelledError):
+        task.exception()


### PR DESCRIPTION
`cancel_all_tasks` have all logics to cancel tasks, and this gives a chance to tasks be canceled
```python
    loop.run_until_complete(
        tasks.gather(*to_cancel, loop=loop, return_exceptions=True))
```