### PR TITLE
Fix sentry integration

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@ Thanks to:
 * luizdepra <luiz.pra@olist.com>
 * wiliamsouza <wiliamsouza83@gmail.com>
 * GuilhermeVBeira <guilherme.vieira.beira@gmail.com>
+* hartungstenio <hartung@live.com>

--- a/docs/source/error_handlers.rst
+++ b/docs/source/error_handlers.rst
@@ -29,11 +29,11 @@ To integrate with `sentry`_ you will need the `sdk`_ client and your account DSN
 
 Then you can automatically create an ``error_handler`` with the following code::
 
+    import sentry_sdk
     from loafer.ext.sentry import sentry_handler
-    from sentry_sdk import init, capture_message
 
-    init(...)
-    error_handler = sentry_handler(capture_message, delete_message=True)
+    sentry_sdk.init(...)
+    error_handler = sentry_handler(sentry_sdk, delete_message=True)
 
 
 The optional ``delete_message`` parameter controls the message acknowledgement

--- a/loafer/ext/sentry.py
+++ b/loafer/ext/sentry.py
@@ -1,12 +1,12 @@
 # TODO: it should be async
 
 
-def sentry_handler(capture_exception, delete_message=False):
+def sentry_handler(sdk_or_hub, delete_message=False):
 
     def send_to_sentry(exc_info, message):
-        scope_kwargs = {"message": message}
-        capture_exception(exc_info, **scope_kwargs)
-
+        with sdk_or_hub.push_scope() as scope:
+            scope.set_extra("message", message)
+            sdk_or_hub.capture_exception(exc_info)
         return delete_message
 
     return send_to_sentry

--- a/tests/ext/test_sentry.py
+++ b/tests/ext/test_sentry.py
@@ -3,19 +3,8 @@ from unittest import mock
 from loafer.ext.sentry import sentry_handler
 
 
-class MockScope:
-    def __init__(self):
-        self.set_extra = mock.Mock()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return None
-
-
 def test_sentry_handler():
-    mock_scope = MockScope()
+    mock_scope = mock.MagicMock()
     sdk_mocked = mock.Mock()
     sdk_mocked.push_scope.return_value = mock_scope
 
@@ -26,14 +15,14 @@ def test_sentry_handler():
 
     assert delete_message is False
     assert sdk_mocked.push_scope.called
-    mock_scope.set_extra.assert_called_once_with(
+    mock_scope.__enter__.return_value.set_extra.assert_called_once_with(
         "message", "test"
     )
     sdk_mocked.capture_exception.assert_called_once_with(exc_info)
 
 
 def test_sentry_handler_delete_message():
-    mock_scope = MockScope()
+    mock_scope = mock.MagicMock()
     sdk_mocked = mock.Mock()
     sdk_mocked.push_scope.return_value = mock_scope
 
@@ -44,7 +33,7 @@ def test_sentry_handler_delete_message():
 
     assert delete_message is True
     assert sdk_mocked.push_scope.called
-    mock_scope.set_extra.assert_called_once_with(
+    mock_scope.__enter__.return_value.set_extra.assert_called_once_with(
         "message", "test"
     )
     sdk_mocked.capture_exception.assert_called_once_with(exc_info)

--- a/tests/ext/test_sentry.py
+++ b/tests/ext/test_sentry.py
@@ -3,29 +3,48 @@ from unittest import mock
 from loafer.ext.sentry import sentry_handler
 
 
+class MockScope:
+    def __init__(self):
+        self.set_extra = mock.Mock()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+
 def test_sentry_handler():
-    capture_exception_mocked = mock.Mock()
-    handler = sentry_handler(capture_exception_mocked)
-    exc = ValueError('test')
+    mock_scope = MockScope()
+    sdk_mocked = mock.Mock()
+    sdk_mocked.push_scope.return_value = mock_scope
+
+    handler = sentry_handler(sdk_mocked)
+    exc = ValueError("test")
     exc_info = (type(exc), exc, None)
-    delete_message = handler(exc_info, 'test')
+    delete_message = handler(exc_info, "test")
 
     assert delete_message is False
-    assert capture_exception_mocked.called
-    capture_exception_mocked.assert_called_once_with(
-        exc_info, message='test',
+    assert sdk_mocked.push_scope.called
+    mock_scope.set_extra.assert_called_once_with(
+        "message", "test"
     )
+    sdk_mocked.capture_exception.assert_called_once_with(exc_info)
 
 
 def test_sentry_handler_delete_message():
-    capture_exception_mocked = mock.Mock()
-    handler = sentry_handler(capture_exception_mocked, delete_message=True)
-    exc = ValueError('test')
+    mock_scope = MockScope()
+    sdk_mocked = mock.Mock()
+    sdk_mocked.push_scope.return_value = mock_scope
+
+    handler = sentry_handler(sdk_mocked, delete_message=True)
+    exc = ValueError("test")
     exc_info = (type(exc), exc, None)
-    delete_message = handler(exc_info, 'test')
+    delete_message = handler(exc_info, "test")
 
     assert delete_message is True
-    assert capture_exception_mocked.called
-    capture_exception_mocked.assert_called_once_with(
-        exc_info, message='test',
+    assert sdk_mocked.push_scope.called
+    mock_scope.set_extra.assert_called_once_with(
+        "message", "test"
     )
+    sdk_mocked.capture_exception.assert_called_once_with(exc_info)


### PR DESCRIPTION
After a few testing, I found out errors were not being to sent to sentry when using this scope_kwargs without pushing a scope.

Testing I did:
```python
sentry_sdk.init(...)

scope_kwargs = {"message": "test"}
sentry_sdk.capture_exception(MyException(), **scope_kwargs) # Does nothing

with sentry_sdk.push_scope() as scope:
    scope.set_extra("message", "test")
    sentry_sdk.capture_exception(MyException()) # This works
```